### PR TITLE
Fix CLI performance on large sized databases

### DIFF
--- a/Command/DoctrineDecryptDatabaseCommand.php
+++ b/Command/DoctrineDecryptDatabaseCommand.php
@@ -101,6 +101,20 @@ class DoctrineDecryptDatabaseCommand extends ContainerAwareCommand
 
             //Create reflectionClass for each meta data object
             $reflectionClass = New \ReflectionClass($metaData->name);
+            $propertyArray = $reflectionClass->getProperties();
+            $propertyCount = 0;
+
+            //Count propperties in metadata
+            foreach ($propertyArray as $property) {
+                if ($annotationReader->getPropertyAnnotation($property, "Ambta\DoctrineEncryptBundle\Configuration\Encrypted")) {
+                    $propertyCount++;
+                }
+            }
+
+            if ($propertyCount === 0) {
+                continue;
+            }
+
 
             //If class is not an superclass
             if (!$annotationReader->getClassAnnotation($reflectionClass, "Doctrine\ORM\Mapping\MappedSuperclass")) {

--- a/Command/DoctrineEncryptDatabaseCommand.php
+++ b/Command/DoctrineEncryptDatabaseCommand.php
@@ -100,6 +100,19 @@ class DoctrineEncryptDatabaseCommand extends ContainerAwareCommand
 
             //Create reflectionClass for each meta data object
             $reflectionClass = New \ReflectionClass($metaData->name);
+            $propertyArray = $reflectionClass->getProperties();
+            $propertyCount = 0;
+
+            //Count propperties in metadata
+            foreach ($propertyArray as $property) {
+                if ($annotationReader->getPropertyAnnotation($property, "Ambta\DoctrineEncryptBundle\Configuration\Encrypted")) {
+                    $propertyCount++;
+                }
+            }
+
+            if ($propertyCount === 0) {
+                continue;
+            }
 
             //If class is not an superclass
             if (!$annotationReader->getClassAnnotation($reflectionClass, "Doctrine\ORM\Mapping\MappedSuperclass")) {


### PR DESCRIPTION
Whats changed?

In the current situation the CLI commands loop over each row in the database to see if the variable should be encrypted or decrypted, however on medium to large sized databases this is really a bad practice. I've changed both commands to only scan through entities which do have the `@encrypted` annotation so we only loop on the data rows which really do require a update to encrypt or decrypt the specific field.
