### PR TITLE
Add quotes to avoid deprecation notice

### DIFF
--- a/Resources/config/orm-services.yml
+++ b/Resources/config/orm-services.yml
@@ -1,7 +1,7 @@
 services:
     ambta_doctrine_encrypt.orm_subscriber:
         class: Ambta\DoctrineEncryptBundle\Subscribers\DoctrineEncryptSubscriber
-        arguments: ["@annotation_reader", %ambta_doctrine_encrypt.encryptor_class_name%, %ambta_doctrine_encrypt.secret_key%]
+        arguments: ["@annotation_reader", "%ambta_doctrine_encrypt.encryptor_class_name%", "%ambta_doctrine_encrypt.secret_key%"]
         tags:
             -  { name: doctrine.event_subscriber }
     ambta_doctrine_encrypt.subscriber:
@@ -9,5 +9,5 @@ services:
     ambta_doctrine_encrypt.encryptor:
         class: Ambta\DoctrineEncryptBundle\Services\Encryptor
         arguments:
-            - %ambta_doctrine_encrypt.encryptor_class_name%
-            - %ambta_doctrine_encrypt.secret_key%
+            - "%ambta_doctrine_encrypt.encryptor_class_name%"
+            - "%ambta_doctrine_encrypt.secret_key%"


### PR DESCRIPTION
Not quoting a scalar starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0.
