### PR TITLE
URGENT: Reverting incorrectly pushed package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "matatirosoln/doctrine-encrypt-bundle",
+    "name": "ambta/doctrine-encrypt-bundle",
     "type": "library",
     "keywords": ["doctrine", "symfony", "aes256", "rijndael", "encrypt", "decrypt"],
     "license": "MIT",


### PR DESCRIPTION
When PR #34 was merged 11 days ago it contained an incorrect modification to the package name.