### PR TITLE
Updates for PHP 7.4

### DIFF
--- a/Encryptors/AES192Encryptor.php
+++ b/Encryptors/AES192Encryptor.php
@@ -40,9 +40,7 @@ class AES192Encryptor implements EncryptorInterface
         $this->secretKey = md5($key);
         $this->suffix = $suffix;
         $this->encryptMethod = sprintf('%s-%s', self::METHOD_NAME, self::ENCRYPT_MODE);
-        $this->initializationVector = openssl_random_pseudo_bytes(
-            openssl_cipher_iv_length($this->encryptMethod)
-        );
+        $this->initializationVector = false;
     }
 
     /**

--- a/Encryptors/AES192Encryptor.php
+++ b/Encryptors/AES192Encryptor.php
@@ -9,8 +9,8 @@ namespace Ambta\DoctrineEncryptBundle\Encryptors;
  */
 class AES192Encryptor implements EncryptorInterface
 {
-    const METHOD_NAME = 'AES-192';
-    const ENCRYPT_MODE = 'ECB';
+    const METHOD_NAME = 'aes-192';
+    const ENCRYPT_MODE = 'ecb';
 
     /**
      * @var string

--- a/Encryptors/AES256Encryptor.php
+++ b/Encryptors/AES256Encryptor.php
@@ -40,9 +40,7 @@ class AES256Encryptor implements EncryptorInterface
         $this->secretKey = md5($key);
         $this->suffix = $suffix;
         $this->encryptMethod = sprintf('%s-%s', self::METHOD_NAME, self::ENCRYPT_MODE);
-        $this->initializationVector = openssl_random_pseudo_bytes(
-            openssl_cipher_iv_length($this->encryptMethod)
-        );
+        $this->initializationVector = false;
     }
 
     /**

--- a/Encryptors/AES256Encryptor.php
+++ b/Encryptors/AES256Encryptor.php
@@ -9,8 +9,8 @@ namespace Ambta\DoctrineEncryptBundle\Encryptors;
  */
 class AES256Encryptor implements EncryptorInterface
 {
-    const METHOD_NAME = 'AES-256';
-    const ENCRYPT_MODE = 'ECB';
+    const METHOD_NAME = 'aes-256';
+    const ENCRYPT_MODE = 'ecb';
 
     /**
      * @var string

--- a/Encryptors/VariableEncryptor.php
+++ b/Encryptors/VariableEncryptor.php
@@ -33,9 +33,7 @@ class VariableEncryptor implements EncryptorInterface
     {
         $this->secretKey = md5($key);
         $this->suffix = $suffix;
-        $this->initializationVector = openssl_random_pseudo_bytes(
-            openssl_cipher_iv_length(self::ENCRYPT_METHOD)
-        );
+        $this->initializationVector = false;
     }
 
     /**

--- a/Encryptors/VariableEncryptor.php
+++ b/Encryptors/VariableEncryptor.php
@@ -9,7 +9,7 @@ namespace Ambta\DoctrineEncryptBundle\Encryptors;
  */
 class VariableEncryptor implements EncryptorInterface
 {
-    const ENCRYPT_METHOD = 'AES-256-ECB';
+    const ENCRYPT_METHOD = 'aes-256-ecb';
 
     /**
      * @var string


### PR DESCRIPTION
In previous versions of PHP / OpenSSL if `openssl_random_pseudo_bytes` was called with 0 it would return false, in PHP 7.4 and the associated newer version of OpenSSL this now fails instead.

Since `openssl_cipher_iv_length($this->encryptMethod)` returns 0 when `$this->encryptMethod` is either aes-192-ecb or aes-256-ecb this leads to a fatal error.

Since the previous result was that `$this->initializationVector` ended up as `False` anyway, this is now explicitly set for those encryptors.

Additionally since OpenSSL 1.1.1 only lowercase encryptors are used.