### PR TITLE
Fix the `Return value of "Ambta\DoctrineEncryptBundle\Command\Doctrin…

### DIFF
--- a/Command/DoctrineEncryptStatusCommand.php
+++ b/Command/DoctrineEncryptStatusCommand.php
@@ -2,6 +2,7 @@
 
 namespace Ambta\DoctrineEncryptBundle\Command;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -53,5 +54,6 @@ class DoctrineEncryptStatusCommand extends AbstractCommand
 
         $output->writeln('');
         $output->writeln(sprintf('<info>%d</info> entities found which are containing <info>%d</info> encrypted properties.', count($metaDataArray), $totalCount));
+        return Command::SUCCESS;
     }
 }


### PR DESCRIPTION
Fix the `Return value of "Ambta\DoctrineEncryptBundle\Command\DoctrineEncryptStatusCommand::execute()" must be of the type int, "null" returned.` error.